### PR TITLE
Restore backward compatibily of topog2mask.py

### DIFF
--- a/topog2mask.py
+++ b/topog2mask.py
@@ -26,8 +26,10 @@ def make_mask(topog_filename, mask_filename, frac, ice=False):
         else:
             mask = mf.createVariable('mask', 'f8', dimensions=('ny', 'nx'))
         # CICE and MOM use 0 as masked
-        mask[:] = np.where((tf.variables['frac'][:] < frac) | (tf.variables['depth'][:] <= 0.0), 0, 1)
-
+        if (frac > 0.0):
+            mask[:] = np.where((tf.variables['frac'][:] < frac) | (tf.variables['depth'][:] <= 0.0), 0, 1)
+        else:
+            mask[:] = np.where(tf.variables['depth'][:] <= 0.0, 0, 1)
 
 def main():
 


### PR DESCRIPTION
This ensures the tool works with topography files that do not include a 'frac' variable.

Closes #7 